### PR TITLE
mecab-ipadic-neologdから熟語を取る

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+name: test-idiom
+
+on: [push]
+jobs:
+  build:
+    runs-on: [ubuntu-latest]
+
+    steps:
+      - run: git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git
+      - run: xz -d mecab-ipadic-neologd/seed/*.xz
+      - run: cat mecab-ipadic-neologd/seed/*.csv | grep -v 人名 |cut -d ',' -f 11 | grep -P '^\p{Han}{2}$'| sort | uniq | tee result
+      - run: wc -l result


### PR DESCRIPTION
github actionsを使ってシェルをちょっとごりっとしてとりあえず取得。
eventとかは補完効いて楽に入れられたけど、run以外の機能を使いこなせていない。

現行が45300くらいなんだけど、ここから取ると45800くらいになってて、意外とお互い信頼できる？みたいな感じ笑

>現行：
https://github.com/erbowl/kanji_cross/blob/master/json/exist.json

気になる結果はこちらから
https://github.com/kanji-cross/infra/commit/f137727fa423eeec811ab150f2e0e7dd3b033818/checks?check_suite_id=412062544

このあとのタスクとしてはどうにか頻出度を手に入れて、なんらかの形のDBに突っ込む。
そんな量ないから意外と現行の1文字目->2文字目のmapと、2文字目->1文字目のmapを持っておくだけでいい気もするけど、どうやってデータを取り出すか次第やなー。